### PR TITLE
fix: support more environments

### DIFF
--- a/settings.py
+++ b/settings.py
@@ -19,14 +19,7 @@ DEFAULT_MODEL = "efficientnet-b0"
 DEFAULT_HDF5_COUNT = 10000000
 EMBEDDINGS_HDF5_PATH = DATA_DIR / "efficientnet-b0.hdf5"
 
-# Should be either 'prod' or 'dev'.
 _ann_instance = os.environ.get("ANN_INSTANCE", "dev")
-
-if _ann_instance != "prod" and _ann_instance != "dev":
-    raise ValueError(
-        "ANN_INSTANCE should be either 'prod' or 'dev', got %s" % _ann_instance
-    )
-
 _sentry_dsn = os.environ.get("SENTRY_DSN")
 
 


### PR DESCRIPTION
We need to be able to run Robotoff ANN locally: this allows more envs than `dev` and `prod`